### PR TITLE
P4-1675 - Fix Kibana Filtering for Discover and Dashboard.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana_object_format",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Enables objects in arrays to be configured with a field formatter.",
   "license": "Apache 2.0",
   "homepage": "https://github.com/istresearch/kibana-object-format",

--- a/public/field_formats/object/cleanFieldTemplate.js
+++ b/public/field_formats/object/cleanFieldTemplate.js
@@ -62,8 +62,6 @@ const cleanTemplate = showPopover => {
 
 export default (showPopover = false) => {
   setTimeout(() => {
-    if ($('.application.tab-discover').length) {
-      cleanTemplate(showPopover);
-    }
+    cleanTemplate(showPopover);
   }, 0);
 };

--- a/public/hacks/custom_filter_bootstrap/index.js
+++ b/public/hacks/custom_filter_bootstrap/index.js
@@ -34,9 +34,7 @@ app.run(['$rootScope', ($rootScope) => {
       popover.destroy();
     }
 
-    if (originalPath.indexOf('/discover/') !== -1 || originalPath.indexOf('/dashboard/') !== -1) {
-      popover.init(); 
-    }
+    popover.init(); 
   });
 }]);
 
@@ -51,7 +49,7 @@ app.run(['$rootScope', ($rootScope) => {
 
   const filterManagerHelper = new FilterManagerHelper(addFiltersCached);
 
-  filterManager.addFilters = (newFilters, a, b, c) => {
+  filterManager.addFilters = newFilters => {
     if (_.isArray(newFilters) && newFilters.length !== 1) {
       return;
     }


### PR DESCRIPTION
## Summary
Issue #1: Custom Filtering is broken for Discover. This happens if the user initially loads the Dashboard page before navigating to Discover.
Issue #2: Custom Filtering is broken for all other pages including Dashboard and Visualize.

## Testing and Verification
- [ ] Load the Dashboard page. Verify that all filters work correctly.
- [ ] Navigate to the Discover page. Verify that all filters work correctly.
- [ ] Load the Discover page. Verify that all filters work correctly.
- [ ] Navigate the Dashboard page. Verify that all filters work correctly.
- [ ] Verify if the Visualize page filters work correctly. (Optional)