### PR TITLE
P4-1680 - Apply latest fix and verify for Kibana 7.7.1 and 7.8.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ export default function(kibana) {
         'plugins/kibana_object_format/hacks/custom_filter_bootstrap',
         'plugins/kibana_object_format/hacks/object_filter',
         'plugins/kibana_object_format/hacks/scroll_bug',
+        'plugins/kibana_object_format/field_formats/object/register',
       ],
-      fieldFormats: ['plugins/kibana_object_format/field_formats/object/register'],
       uiSettingDefaults: {
         'fieldMapperHack:fields': {
           value:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana_object_format",
-  "version": "0.1.9",
+  "version": "0.1.8",
   "description": "Enables objects in arrays to be configured with a field formatter.",
   "license": "Apache 2.0",
   "homepage": "https://github.com/istresearch/kibana-object-format",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "kibana_object_format",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Enables objects in arrays to be configured with a field formatter.",
   "license": "Apache 2.0",
   "homepage": "https://github.com/istresearch/kibana-object-format",
   "main": "index.js",
   "kibana": {
-    "version": "7.6.2",
+    "version": "kibana",
     "templateVersion": "1.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana_object_format",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Enables objects in arrays to be configured with a field formatter.",
   "license": "Apache 2.0",
   "homepage": "https://github.com/istresearch/kibana-object-format",

--- a/public/field_formats/object/cleanFieldTemplate.js
+++ b/public/field_formats/object/cleanFieldTemplate.js
@@ -62,8 +62,6 @@ const cleanTemplate = showPopover => {
 
 export default (showPopover = false) => {
   setTimeout(() => {
-    if ($('.application.tab-discover').length) {
-      cleanTemplate(showPopover);
-    }
+    cleanTemplate(showPopover);
   }, 0);
 };

--- a/public/field_formats/object/object.js
+++ b/public/field_formats/object/object.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { FieldFormat } from '../../../../../src/plugins/data/public';
+import { FieldFormat } from '../../../../../src/plugins/data/common/field_formats/field_format';
 import { getHighlightHtml } from '../../common/highlight';
 import { lodashOopMixin } from '../../common/lodash-mixins/oop';
 import { lodashGetPluckMixin } from '../../common/lodash-mixins/get_pluck';

--- a/public/hacks/custom_filter_bootstrap/index.js
+++ b/public/hacks/custom_filter_bootstrap/index.js
@@ -34,34 +34,30 @@ app.run(['$rootScope', ($rootScope) => {
       popover.destroy();
     }
 
-    if (originalPath.indexOf('/discover/') !== -1) {
-      popover.init();
-    }
+    popover.init(); 
   });
 }]);
 
 (async (indexPatterns, addFiltersCached) => {
-  const indexPatternList = await indexPatterns.getFields(['id', 'title']);
-  let selectedIndexPattern = null;
+  const indexPatternIDList = await indexPatterns.getFields(['id']);
+  let indexPatternLookup = {};
+
+  for (let pattern of indexPatternIDList) {
+    let ip = await indexPatterns.get(pattern.id);
+    indexPatternLookup[pattern.id] = ip.fieldFormatMap;
+  }
 
   const filterManagerHelper = new FilterManagerHelper(addFiltersCached);
-
-  await $('body').observe('.indexPattern__triggerButton', async () => {
-    const ipTitle = $('.indexPattern__triggerButton > span > span').text();
-    const ip = indexPatternList.filter(ipItem => ipItem.title === ipTitle);
-    if (ip.length === 1) {
-      selectedIndexPattern = await indexPatterns.get(ip[0].id);
-    }
-  });
 
   filterManager.addFilters = newFilters => {
     if (_.isArray(newFilters) && newFilters.length !== 1) {
       return;
     }
 
-    const { fieldFormatMap } = selectedIndexPattern;
-
     const newFilter = newFilters[0];
+
+    const selectedIndexPatternID =  _.get(newFilter, 'meta.index', null);  
+    const fieldFormatMap = indexPatternLookup[selectedIndexPatternID];
     const matchPhrase =  _.get(newFilter, 'query.match_phrase', {});
     const fieldNameKeys = Object.keys(matchPhrase);
     


### PR DESCRIPTION
## Summary
Updated to v7.7.1
- Verify that the plugin works on Kibana v7.7.1

Applied P4-1675 Hot Fix:
- Fixed Issue #1: Custom Filtering is broken for Discover. This happens if the user initially loads the Dashboard page before navigating to Discover.
- Fixed ssue #2: Custom Filtering is broken for all other pages including Dashboard and Visualize.

## Testing and Verification
- [ ] Verify that the plugin works on Kibana v7.7.1
- [ ] Verify that the plugin works on Kibana v7.8.0

For both v7.7.1 and v7.80: (Firefox)
- [ ] Load the Dashboard page. Verify that all filters work correctly.
- [ ] Navigate to the Discover page. Verify that all filters work correctly.
- [ ] Load the Discover page. Verify that all filters work correctly.
- [ ] Navigate the Dashboard page. Verify that all filters work correctly.
- [ ] Verify if the Visualize page filters work correctly. (Optional)

**Kibana 7.8.0 Screenshots:**

<img width="1084" alt="Screen Shot 2020-06-23 at 8 21 54 PM" src="https://user-images.githubusercontent.com/23508216/85486554-7325da00-b590-11ea-876e-d1b6d25e5a1d.png">
<img width="1080" alt="Screen Shot 2020-06-23 at 8 27 58 PM" src="https://user-images.githubusercontent.com/23508216/85486558-74570700-b590-11ea-9158-a856aa4e9704.png">
<img width="1083" alt="Screen Shot 2020-06-23 at 8 29 31 PM" src="https://user-images.githubusercontent.com/23508216/85486549-70c38000-b590-11ea-9fdb-ffb10db5c484.png">
