### PR TITLE
P4-1787 - Object and Rule Formatter CSV Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { registerFieldFormats } from './server/field-formatters';
+
 export default function(kibana) {
   return new kibana.Plugin({
     require: ['kibana'],
@@ -20,7 +22,9 @@ export default function(kibana) {
         },
       },
     },
-
+    init: async function(server) {
+      registerFieldFormats(server);
+    },
     config(Joi) {
       return Joi.object({
         enabled: Joi.boolean().default(true),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana_object_format",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Enables objects in arrays to be configured with a field formatter.",
   "license": "Apache 2.0",
   "homepage": "https://github.com/istresearch/kibana-object-format",

--- a/server/field-formatters/ObjectFieldFormatStub.js
+++ b/server/field-formatters/ObjectFieldFormatStub.js
@@ -1,0 +1,15 @@
+import { FieldFormat } from '../../../../src/plugins/data/common/field_formats/field_format';
+
+export class ObjectFieldFormatStub extends FieldFormat {
+  constructor(params) {
+    super(params);
+  }
+
+  static id = 'ist-object';
+  static title = 'Object';
+
+  getParamDefaults() {
+    return {};
+  }
+}
+ 

--- a/server/field-formatters/index.js
+++ b/server/field-formatters/index.js
@@ -1,0 +1,5 @@
+import { ObjectFieldFormatStub } from './ObjectFieldFormatStub';
+
+export function registerFieldFormats(server) {
+  server.registerFieldFormat(ObjectFieldFormatStub);
+}


### PR DESCRIPTION
Companion PR:  **https://github.com/istresearch/pulse-kibana-plugins/pull/12**

This will remove the constructor error and allow users to generate a csv if no nested fields are selected.

- [ ] Install both the updated kibana-object-format and pulse-kibana-plugins.
- [ ] In Discover tab, make sure that there are no nested fields selected. If nested fields are selected, an error will appear.
- [ ] Export CSV should work generating a csv file with all fields and rows. The nested fields are automatically stringified in the appropriate columns.
 