### PR TITLE
P4-1799 - Object and Rule Formatter CSV Support (7.8.1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ export default function(kibana) {
         },
       },
     },
-    init: async function(server) {
+    async init(server) {
       registerFieldFormats(server);
     },
     config(Joi) {

--- a/server/field-formatters/index.js
+++ b/server/field-formatters/index.js
@@ -1,5 +1,5 @@
 import { ObjectFieldFormatStub } from './ObjectFieldFormatStub';
 
 export function registerFieldFormats(server) {
-  server.registerFieldFormat(ObjectFieldFormatStub);
+  server.newPlatform.setup.plugins.data.fieldFormats.register(ObjectFieldFormatStub);
 }


### PR DESCRIPTION
This will remove the constructor error and allow users to generate a csv if no nested fields are selected.

- [ ] Install both the updated kibana-object-format and pulse-kibana-plugins.
- [ ] In Discover tab, make sure that there are no nested fields selected. If nested fields are selected, an error will appear.
- [ ] Export CSV should work generating a csv file with all fields and rows. The nested fields are automatically stringified in the appropriate columns.
 